### PR TITLE
Merge supported features of grouped elements

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -523,7 +523,6 @@ class Group(Entity):
             data[ATTR_VIEW] = True
         if self.control:
             data[ATTR_CONTROL] = self.control
-            
         return data
 
     @property

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -8,6 +8,8 @@ import asyncio
 import logging
 import os
 
+from functools import reduce
+
 import voluptuous as vol
 
 from homeassistant import config as conf_util, core as ha
@@ -508,6 +510,15 @@ class Group(Entity):
             data[ATTR_VIEW] = True
         if self.control:
             data[ATTR_CONTROL] = self.control
+
+        try:
+          sub_entities = [self.hass.states.get(eid) for eid in data[ATTR_ENTITY_ID]]
+          attributes = [e.attributes for e in sub_entities if e is not None]
+          features = [a[ATTR_SUPPORTED_FEATURES] for a in attributes if a is not None]
+          data[ATTR_SUPPORTED_FEATURES] = reduce(lambda f1,f2: f1 & f2, features)
+        except:
+          pass
+            
         return data
 
     @property

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -258,7 +258,7 @@ def get_common_supported_features(hass, entity_ids):
                 if e is not None and hasattr(e, 'attributes')]
 
     # Return merged supported features in a "common features only" manner
-    return reduce(lambda f1,f2: f1 & f2, features) if len(features) > 0 else 0
+    return reduce(operator.and_, features) if len(features) > 0 else 0
 
 @asyncio.coroutine
 def async_setup(hass, config):


### PR DESCRIPTION
Allows e.g. to group dimmable lights. This among others helps Google Assistant component.

## Description:

The component `Google Assistant` works with the `supported_feature` attribute of entities to find what traits it proposes to Google. However, `groups` dont have that attribute. This update merges the supported features of the grouped entities in a GCD way and safes it to the groups attributes.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
group:
  TwoDimmableBulbsLight:
    entities:
       - light.light1
       - light.light2

group.twodimmablebulbslight:
  google_assistant: true
  google_assistant_type: light
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - [ ] ~~New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - [ ] ~~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - [ ] ~~New files were added to `.coveragerc`.~~

<del>
If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
</del>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  